### PR TITLE
fixed type conversion issue in search_load_toa5df caused by presence …

### DIFF
--- a/hievpy/__init__.py
+++ b/hievpy/__init__.py
@@ -153,7 +153,8 @@ def toa5_summary(api_token, record):
         download_url = f"{record['url']}?auth_token={api_token}"
         req = urllib.request.urlopen(download_url)
         data = req.read()
-        df = pd.read_csv(io.StringIO(data.decode('utf-8')), skiprows=1, header=None)
+        df = pd.read_csv(io.StringIO(data.decode('utf-8')),
+                         skiprows=1, header=None)
         for column in df:
             print("  ".join(str(x) for x in df[column][0:3].values))
     else:
@@ -189,12 +190,13 @@ def search_load_toa5df(api_token, base_url, search_params):
         download_url = f"{record['url']}?auth_token={api_token}"
         req = urllib.request.urlopen(download_url)
         data = req.read()
-        df = pd.read_csv(io.StringIO(data.decode('utf-8')), skiprows=[0, 2, 3], na_values='NAN')
+        df = pd.read_csv(io.StringIO(data.decode('utf-8')),
+                         skiprows=[0, 2, 3], na_values='NAN')
 
         # Remove the units and measurement type rows
         df = df.set_index('TIMESTAMP')
         df.index = pd.to_datetime(df.index)
-        df = df.apply(pd.to_numeric)
+        df = df.infer_objects()
         df_all = pd.concat([df_all, df])
 
     if 'from_date' in search_params:


### PR DESCRIPTION
…of strings in toa5 file

The below code produced: ValueError: ('Unable to parse string "DATA" at position 0', 'occurred at index DATAH') due to trying to convert a string into numeric data types.

```python
import hievpy as hp
import os

api_token = os.environ['HIEV_API_KEY']

df = hp.search_load_toa5df(api_token=api_token,
                           base_url='https://hiev.uws.edu.au/',
                           search_params={'filename': 'CUP_AUTO_flux_data'})

print(df.info()) 
```